### PR TITLE
performance: use DWARF to find call graphs

### DIFF
--- a/performance.md
+++ b/performance.md
@@ -107,11 +107,11 @@ Let's assume we have compiled the above code using `swift build -c release` into
 
 ```
 # Step 1: Record the stack frames with a 99 Hz sampling frequency
-sudo perf record -F 99 -g -- ./slow
+sudo perf record -F 99 --call-graph dwarf -- ./slow
 # Alternatively, to attach to an existing process use
-#     sudo perf record -F 99 -g -p PID_OF_SLOW
+#     sudo perf record -F 99 --call-graph dwarf -p PID_OF_SLOW
 # or if you don't know the pid, you can try (assuming your binary name is "slow")
-#     sudo perf record -F 99 -g -p $(pgrep slow)
+#     sudo perf record -F 99 --call-graph dwarf -p $(pgrep slow)
 
 # Step 2: Export the recording into `out.perf`
 sudo perf script > out.perf


### PR DESCRIPTION
DWARF should give us better call graphs than relying on the frame pointer (`fp` which is the default).