### PR TITLE
Grammar changes and minor cleanup suggestions

### DIFF
--- a/log-levels.md
+++ b/log-levels.md
@@ -1,10 +1,10 @@
-# Log Levels 
+# Log Levels
 
 This guide serves as guidelines for library authors with regards to what [SwiftLog](https://github.com/apple/swift-log) log levels are apropriate for use in libraries, and in what siuations to use what level.
 
 ## Guidelines for Libraries
 
-SwiftLog defines the following 7 log levels via the [`Logger.Level` enum](https://apple.github.io/swift-log/docs/current/Logging/Structs/Logger/Level.html), ordered from least to most severe: 
+SwiftLog defines the following 7 log levels via the [`Logger.Level` enum](https://apple.github.io/swift-log/docs/current/Logging/Structs/Logger/Level.html), ordered from least to most severe:
 
 * `trace`
 * `debug`
@@ -47,51 +47,51 @@ Some libraries and situations may not be entirely clear with regards to what log
 
 `trace` level logging:
 
-- could include various additional information about a request, such as various diagnostics about created data structures, the state of caches or similar, which are created in order to serve a request.
-- could include "begin operation" and "end operation" logs, 
-  - however, please consider using swift-distributed-tracing to instrument such "begin/end" events as tracing can be more efficient than logging which may need to create string representations of the durations and log levels etc.
+- Could include various additional information about a request, such as various diagnostics about created data structures, the state of caches or similar, which are created in order to serve a request.
+- Could include "begin operation" and "end operation" logs.
+  - However, please consider using [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing) to instrument "begin" and "end" events, as tracing can be more efficient than logging. Logging may need to create string representations of the durations, log levels, and other fields.
 
 `debug` level logging:
 
-- may include a single log statement for opening a connection, or accepting a request etc,
-- it can include a _high level_ overview of what is going on in the library "started work, processing step X, finished work X, result code 200"
+- May include a single log statement for opening a connection, accepting a request, and so on.
+- It can include a _high level_ overview of what is going on in the library. For example: "started work, processing step X, finished work X, result code 200".
 
 ### Log levels to avoid
 
 All these rules are only _general_ guidelines, and as such may have exceptions. Consider the following examples and rationale for why logging at high log levels by a library may not be desirable:
 
-It is generally _not acceptable_ for a service client (e.g. an http client) to log an `error` when a request has failed. End-users may be using the client to probe if an endpoint is even responsive or not, and a failure to respond may be _expected_ behavior. Logging errors would only confuse and pollute their logs.
+It is generally _not acceptable_ for a service client (for example, an http client) to log an `error` when a request has failed. End-users may be using the client to probe if an endpoint is even responsive or not, and a failure to respond may be _expected_ behavior. Logging errors would only confuse and pollute their logs.
 
 Instead, libraries should either `throw`, or return an `Error` value that users of the library will have enough knowladge about if they should log or ignore it.
 
-It is even less acceptable for a library to log any successful operations. This leads to flooding server side systems, especially if e.g. one were to log every successfully handled request in a server side application this can easily flood and overwhelm logging systems when deployed to production where many end users are connected to the same server. Such issues are rarely found in development time, because of only a single peer requesting things from the service-under-test.
+It is even less acceptable for a library to log any successful operations. This leads to flooding server side systems, especially if, for example, one were to log every successfully handled request. In a server side application, this can easily flood and overwhelm logging systems when deployed to production where many end users are connected to the same server. Such issues are rarely found in development time, because of only a single peer requesting things from the service-under-test.
 
 #### Examples (of things to avoid)
 
 Avoid using `info` or any higher log level for:
 
-- "normal operation" of the library, i.e. there is no need to log on info level "accepted a request" as this is the normal operation of a web service.
+- "Normal operation" of the library, that is there is no need to log on info level "accepted a request" as this is the normal operation of a web service.
 
 Avoid using `error` or `warning`:
 
-- to report errors which the end-user of the library has the means of logging themselfes, e.g. if a database driver fails to fetch all rows of a query, it should not log an error or warning, but instead e.g. error the stream of values (or function, async function, or even the async sequence) that was representing the returned values.
-  - since the end-user is consuming these values, and has a mean of reporting (or swallowing) this error, the library should not log anything on their behalf.
-- never report as warnings which is merely an information, e.g. "weird header detected" may look like a good idea to log as a warning at first sight, however if the "weird header" is simply a misconfigured client (or just a "weird browser") you may be accidentally completely flooding an end-users logs with these "weird header" warnings (!)
-  - only log warnings about actionable things which the end-user of your library can do something about. Using the "weird header detected" log statement as an example: it would not be a good candidate to log as a warning because the server developer has no way to fix the users of their service to stop sending weird headers, so the server should not be logging this information as a warning.
-- It may be tempting to implement a "log as warning only once" technique for per-request style situations which may be almost important enough to be a warning, but should not be logged repeatedly after all. Authors may think of smart techniques to log a warning only once per "weird header discovered" and later on log the same issue on a different, e.g. trace level... Such techniques result in confusing hard to debug logs, where developers of a system unaware of the stateful nature of the logging would be left confused when trying to reproduce the issue. 
-  - For example, if a developer spots such a warning in a production system, they may attempt to reproduce it -- thinking that it only happens in the production environment. However, if the logging system's log level choice is _stateful_ they may actually be successfully reproducing the issue but never seeing it manifest. For this, and related performance reasons (as implementing "only once per X" implies growing storage and per-request additional checking requirements), it is not recommended to apply this pattern.
+- To report errors which the end-user of the library has the means of logging themselves. For example, if a database driver fails to fetch all rows of a query, it should not log an error or warning, but instead return or throw an error on the stream of values (or function, async function, or even the async sequence) that was providing the returned values.
+  - Since the end-user is consuming these values, and has a mean of reporting (or swallowing) this error, the library should not log anything on their behalf.
+- Never report as warnings which is merely an information. For example. "weird header detected" may look like a good idea to log as a warning at first sight, however if the "weird header" is simply a misconfigured client (or just a "weird browser") you may be accidentally completely flooding an end-users logs with these "weird header" warnings (!)
+  - Only log warnings about actionable things which the end-user of your library can do something about. Using the the "weird header detected" log statement as an example: it would not be a good candidate to log as a warning because the server developer has no way to fix the users of their service to stop sending weird headers, so the server should not be logging this information as a warning.
+- It may be tempting to implement a "log as warning only once" technique for per-request style situations which may be almost important enough to be a warning, but should not be logged repeatedly after all. Authors may think of smart techniques to log a warning only once per "weird header discovered" and later on log the same issue on a different level, such as trace... Such techniques result in confusing hard to debug logs, where developers of a system unaware of the stateful nature of the logging would be left confused when trying to reproduce the issue.
+  - For example, if a developer spots such a warning in a production system, they may attempt to reproduce it — thinking that it only happens in the production environment. However, if the logging system's log level choice is _stateful_ they may actually be successfully reproducing the issue but never seeing it manifest. For this, and related performance reasons (as implementing "only once per X" implies growing storage and per-request additional checking requirements), it is not recommended to apply this pattern.
 
 Exceptions to the "avoid logging warnings" rule:
 
-- "background processes" such as tasks scheduled on a periodic timer, may not have any other means of communicating a failure or warning to the end user of the library other than through logging.
-  - consider offering an API that would collect errors at runtime, and then you can avoid logging errors manually. This can often take the form of a customizable "on error" hook that the library accepts when constructing the scheduled job. If the handler is not customized, we can log the errors, but if it was, it again is up to the end-user of the library to decide what to do with them.
+- "Background processes" such as tasks scheduled on a periodic timer, may not have any other means of communicating a failure or warning to the end user of the library other than through logging.
+  - Consider offering an API that would collect errors at runtime, and then you can avoid logging errors manually. This can often take the form of a customizable "on error" hook that the library accepts when constructing the scheduled job. If the handler is not customized, we can log the errors, but if it was, it again is up to the end-user of the library to decide what to do with them.
 - An exception to the "log a warning only once" rule is when things do not happen very frequently. For example, if a library is warning about an outdated license or something similar during _its initialization_ this isn't necessarily a bad idea. After all, we'd rather see this warning once during initialization rather during every request made to the library. Use your best judgement and consider the developers using your library when designing how often and where from to log such information.
 
 ### Suggested logging style
 
 While libraries are free to use whichever logging message style they choose, here are some best practices to follow if you want users of your libraries to *love* the logs your library produces.
 
-Firstly, it is important to remember that both the message of a log statement as well as the metadata in [swift-log](https://github.com/apple/swift-log) are [autoclosures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html#ID543), which are only invoked if the logger has a log level set such that it must emit a message for the message given. As such, messages e.g. logged at `trace` do not "materialize" their string and metadata representation unless they are actually needed:
+Firstly, it is important to remember that both the message of a log statement as well as the metadata in [swift-log](https://github.com/apple/swift-log) are [autoclosures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html#ID543), which are only invoked if the logger has a log level set such that it must emit a message for the message given. As such, messages logged at `trace` do not "materialize" their string and metadata representation unless they are actually needed:
 
 ```swift
     public func debug(_ message: @autoclosure () -> Logger.Message,
@@ -100,11 +100,11 @@ Firstly, it is important to remember that both the message of a log statement as
                       file: String = #file, function: String = #function, line: UInt = #line) {
 ```
 
-And a minor yet important hint: avoid inserting newlines and other control characters into log statements (!). Many log aggregation systems assume that a single line in a logged output is specifically "one log statement" which can accidentally break if we log not sanitized, potentially multi-line, strings. This isn't a problem for _all_ log backends, e.g. some will automatically sanitize and form a JSON payload with `{message: "..."}` before emitting it to a backend service collecting the logs, but plain old stream (or file) loggers usually assume that one line equals one log statement - it also makes grepping through logs more reliable.
+And a minor yet important hint: avoid inserting newlines and other control characters into log statements (!). Many log aggregation systems assume that a single line in a logged output is specifically "one log statement" which can accidentally break if we log not sanitized, potentially multi-line, strings. This isn't a problem for _all_ log backends. For example, some will automatically sanitize and form a JSON payload with `{message: "..."}` before emitting it to a backend service collecting the logs, but plain old stream (or file) loggers usually assume that one line equals one log statement. It also makes grepping through logs more reliable.
 
 #### Structured Logging (Semantic Logging)
 
-Libraries may want to embrace the structured logging style. 
+Libraries may want to embrace the structured logging style.
 
 It is a fantastic pattern which makes consuming logs in automated systems, and through grepping and other means much easier and future proof.
 
@@ -117,10 +117,10 @@ log.info("Accepted connection \(connection.id) from \(connection.peer), total: \
 
 It contains 4 peieces of information:
 
-- we accepted a connection,
-- this is its string representation,
-- it is from this peer,
-- we currently have `connections.count` active connections.
+- We accepted a connection.
+- This is its string representation.
+- It is from this peer.
+- We currently have `connections.count` active connections.
 
 While this log statement contains all useful information that we meant to relay to end users, it is hard to visually and mechanically parse the detailed information it contains. For example, if we know connections start failing around the time when we reach a total of 100 concurrent connections, it is not trivial to find the specific log statement at which we hit this number. We would have to `grep 'total: 100'` for example, however perhaps there are many other `"total: "` strings present in all of our log systems.
 
@@ -133,26 +133,26 @@ log.info("Accepted connection", metadata: [
   "connections.total": "\(connections.count)"
 ])
 
-// e.g. output:
+// example output:
 // <date> info [connection.id:?,connection.peer:?, connections.total:?] Accepted connection
 ```
 
-which can be formatted, depending on the logging backend, slightly differently on various systems, but even in the simple string representation of such a log, we'd be able to grep for `connections.total: 100` rather than having to guess the right string to grep for.
+This structured log can be formatted, depending on the logging backend, slightly differently on various systems. Even in the simple string representation of such log, we'd be able to grep for `connections.total: 100` rather than having to guess the correct string.
 
-Also, since the message now does not contain all that much "human readable wording", it is less prone to randomly change from "Accepted" to "We have accepted" or vice versa which could break alerting systems which are set up to parse and alert on specific log messages.
+Also, since the message now does not contain all that much "human readable wording", it is less prone to randomly change from "Accepted" to "We have accepted" or vice versa. This kind of change could break alerting systems which are set up to parse and alert on specific log messages.
 
 Structured logs are very useful in combination with [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing)'s `LoggingContext`, which automatically populates the metadata with any present trace information. Thanks to this, all logs made in response to some specific request will automatically carry the same TraceID.
 
 You can see more examples of structured logging on the following pages, and example implementations thereof:
 
-- https://tersesystems.com/blog/2020/05/26/why-i-wrote-a-logging-library/
-- https://cloud.google.com/logging/docs/structured-logging
-- https://stackify.com/what-is-structured-logging-and-why-developers-need-it/
-- https://kubernetes.io/blog/2020/09/04/kubernetes-1-19-introducing-structured-logs/
+- <https://tersesystems.com/blog/2020/05/26/why-i-wrote-a-logging-library/>
+- <https://cloud.google.com/logging/docs/structured-logging>
+- <https://stackify.com/what-is-structured-logging-and-why-developers-need-it/>
+- <https://kubernetes.io/blog/2020/09/04/kubernetes-1-19-introducing-structured-logs/>
 
 #### Logging with Correlation IDs / Trace IDs
 
-A very common pattern is to log messages with some "correlation id". The best approach in general here is to use a `LoggingContext` from [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing) as then your library will be able to be traced and used with correlation contexts regardless what tracing system the end-user is using (e.g. open telemetry, zipkin, xray etc.) The concept though can be explained well with just a manually logged `requestID` which we'll explain below.
+A very common pattern is to log messages with some "correlation id". The best approach in general here is to use a `LoggingContext` from [swift-distributed-tracing](https://github.com/apple/swift-distributed-tracing) as then your library will be able to be traced and used with correlation contexts regardless what tracing system the end-user is using (such as open telemetry, zipkin, xray, and other tracing systems) The concept though can be explained well with just a manually logged `requestID` which we'll explain below.
 
 Consider an HTTP client as an example of a library that has a lot of metadata about some request, perhaps something like this:
 
@@ -179,13 +179,13 @@ log.trace("Somehing something...", metadata: ["id": "..."])
 log.trace("Finished streaming response", metadata: ["id": "..."]) // good, the same ID is propagated
 ```
 
-Thanks to the correlation ID (or a tracing provided ID, in which case we'd log as `context.log.trace("...")` as the ID is propagated automatically), in each following log statement after the initial log statement we're able to correlate all those log statements and know that this `"Finished streaming response"` message was about a response with a `responseCode` that we're able to look up from the `"Received response"` log message.
+Thanks to the correlation ID (or a tracing provided ID, in which case we'd log as `context.log.trace("...")` as the ID is propagated automatically), in each following log statement after the initial log statement we're able to correlate all those log statements. Then we know that this `"Finished streaming response"` message was about a response with a `responseCode` that we're able to look up from the `"Received response"` log message.
 
 This pattern is somewhat advanced and may not always be the right approach, but consider it in high performance code where logging the same information repeatedly can be too costly.
 
 ##### Things to avoid with Correlation ID logging
 
-When logging with correlation contexts make sure to never "drop the ID", it is easiest to get this right when using distributed tracing's `LoggingContext` since propagating it ensures the carrying of identifiers, however the same applies to any kind of correlation identifier.
+When logging with correlation contexts make sure to never "drop the ID". It is easiest to get this right when using distributed tracing's `LoggingContext` since propagating it ensures the carrying of identifiers, however the same applies to any kind of correlation identifier.
 
 Specifically, avoid situations like these:
 
@@ -204,6 +204,6 @@ Here are a few examples of situations when logging a message on a relatively hig
 
 It's permittable for a library to log at `critical` level right before a _hard crash_, as a last resort of informing the log collection systems or end-user about additional information detailing the reason for the crash. This should be _in addition to_ the message from a `fatalError` and can lead to an improved diagnosis/debugging experience for end users.
 
-Sometimes libraries may be able to detect a harmful misconfiguration of the library, for example, selecting deprecated protocol versions. In such situations it may be useful to inform users in production by issuing a `warning`. However you should ensure that the warning is not logged repeatedly! For example, it is not acceptable for an HTTP client to log a warning on every single http request using some misconfiguration of the client. It _may_ be acceptable however for the client to log such warning e.g. _once_ at configuration time, if the library has a good way to do this.
+Sometimes libraries may be able to detect a harmful misconfiguration of the library. For example, selecting deprecated protocol versions. In such situations it may be useful to inform users in production by issuing a `warning`. However you should ensure that the warning is not logged repeatedly! For example, it is not acceptable for an HTTP client to log a warning on every single http request using some misconfiguration of the client. It _may_ be acceptable however for the client to log such warning, for example, _once_ at configuration time, if the library has a good way to do this.
 
-Some libraries may implement a "log this warning only once" or "log this warning only at startup", or "log this error only once an hour" or similar tricks to keep the noise level low but still informative enough to not be missed. This is usually a pattern reserved for stateful long running libraries, rather than clients of databases etc however.
+Some libraries may implement a "log this warning only once", "log this warning only at startup", "log this error only once an hour", or similar tricks to keep the noise level low but still informative enough to not be missed. This is, however, usually a pattern reserved for stateful long running libraries, rather than clients of databases and related persistent stores.


### PR DESCRIPTION
I thought the use of latin abbreviations made some of these sentences quite difficult to parse, so I went through and removed them (e.g., i.e., and etc.), replacing them with more direct english. I also broke up some sentences into multiple parts to make them easier to parse, and applied a bit of sentence capitalization to the bullet lists.

I tried to *not* change any semantic meanings. In at least one section, the sentence didn't quite parse for me though, so I did my best to bring it back to what was intended when I removed the latin abbreviations.