### PR TITLE
Enable static linking

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -24,7 +24,7 @@ COPY . /workspace
 RUN swift build -c release --static-swift-stdlib
 
 #------- package -------
-FROM centos8
+FROM centos
 # copy executables
 COPY --from=builder /workspace/.build/release/<executable-name> /
 


### PR DESCRIPTION
Enables static linking for building and don't use nightlies for the Docker images